### PR TITLE
Implement configurable settings UI

### DIFF
--- a/window_clock.py
+++ b/window_clock.py
@@ -1,7 +1,31 @@
 import argparse
 import tkinter as tk
-from tkinter import colorchooser, simpledialog
+from tkinter import colorchooser, ttk, font
 from datetime import datetime
+
+
+def enumerate_monitors(root):
+    """Best effort attempt to list monitors."""
+    monitors = []
+    try:
+        from screeninfo import get_monitors
+        monitors = get_monitors()
+    except Exception:
+        pass
+
+    if not monitors:
+        # Fallback to single monitor using Tk info
+        class _Monitor:
+            def __init__(self, width, height, x=0, y=0, name="Default"):
+                self.width = width
+                self.height = height
+                self.x = x
+                self.y = y
+                self.name = name
+
+        monitors = [_Monitor(root.winfo_screenwidth(), root.winfo_screenheight())]
+
+    return monitors
 
 
 def parse_args():
@@ -18,9 +42,16 @@ class WindowClock:
         self.font_size = font_size
         self.time_format = time_format
 
+        self.font_family = 'Helvetica'
+        self.selected_monitor_index = 0
+
         # Main window will hold settings
         self.settings_root = tk.Tk()
         self.settings_root.title("Clock Settings")
+
+        # Populate settings UI
+        self.monitors = enumerate_monitors(self.settings_root)
+        self.create_settings_ui()
 
         # Separate borderless window for the clock display
         self.clock_window = tk.Toplevel(self.settings_root)
@@ -28,36 +59,62 @@ class WindowClock:
         self.clock_window.configure(bg=self.bg_color)
 
         self.label = tk.Label(self.clock_window, fg='white', bg=self.bg_color,
-                              font=('Helvetica', self.font_size))
-        self.label.pack(padx=20, pady=20)
+                              font=(self.font_family, self.font_size))
+        self.label.pack(expand=True, fill="both")
 
-        self.create_menu()
+        self.apply_settings()
         self.update_clock()
 
-    def create_menu(self):
-        menubar = tk.Menu(self.settings_root)
-        settings_menu = tk.Menu(menubar, tearoff=0)
-        settings_menu.add_command(label="Background Color", command=self.change_bg_color)
-        settings_menu.add_command(label="Font Size", command=self.change_font_size)
-        settings_menu.add_command(label="Toggle 12/24 Hour", command=self.toggle_format)
-        menubar.add_cascade(label="Settings", menu=settings_menu)
-        self.settings_root.config(menu=menubar)
+    def create_settings_ui(self):
+        fonts = list(font.families())
+        self.font_var = tk.StringVar(value=self.font_family)
+        self.font_size_var = tk.IntVar(value=self.font_size)
+        self.monitor_names = [getattr(m, 'name', f"{i}") for i, m in enumerate(self.monitors)]
+        self.monitor_var = tk.StringVar(value=self.monitor_names[self.selected_monitor_index])
+
+        # Monitor selection
+        tk.Label(self.settings_root, text="Monitor:").grid(row=0, column=0, sticky="e")
+        ttk.Combobox(self.settings_root, textvariable=self.monitor_var, values=self.monitor_names, state="readonly").grid(row=0, column=1, pady=2)
+
+        # Font family selection
+        tk.Label(self.settings_root, text="Font:").grid(row=1, column=0, sticky="e")
+        ttk.Combobox(self.settings_root, textvariable=self.font_var, values=fonts, state="readonly").grid(row=1, column=1, pady=2)
+
+        # Font size spinbox
+        tk.Label(self.settings_root, text="Font Size:").grid(row=2, column=0, sticky="e")
+        tk.Spinbox(self.settings_root, from_=10, to=400, textvariable=self.font_size_var).grid(row=2, column=1, pady=2)
+
+        # Background color button
+        tk.Button(self.settings_root, text="Background Color", command=self.change_bg_color).grid(row=3, column=0, columnspan=2, pady=2)
+
+        # Format toggle button
+        tk.Button(self.settings_root, text="Toggle 12/24 Hour", command=self.toggle_format).grid(row=4, column=0, columnspan=2, pady=2)
+
+        # Apply settings
+        tk.Button(self.settings_root, text="Apply", command=self.apply_settings).grid(row=5, column=0, pady=5)
+        tk.Button(self.settings_root, text="Quit", command=self.settings_root.quit).grid(row=5, column=1, pady=5)
 
     def change_bg_color(self):
         color = colorchooser.askcolor(title="Choose background color", color=self.bg_color)[1]
         if color:
             self.bg_color = color
-            self.clock_window.configure(bg=self.bg_color)
-            self.label.configure(bg=self.bg_color)
-
-    def change_font_size(self):
-        size = simpledialog.askinteger("Font Size", "Enter font size", initialvalue=self.font_size, parent=self.settings_root)
-        if size:
-            self.font_size = size
-            self.label.configure(font=('Helvetica', self.font_size))
+            self.apply_settings()
 
     def toggle_format(self):
         self.time_format = '12' if self.time_format == '24' else '24'
+        self.update_clock()
+
+    def apply_settings(self):
+        self.font_family = self.font_var.get()
+        self.font_size = self.font_size_var.get()
+        if self.monitor_var.get() in self.monitor_names:
+            self.selected_monitor_index = self.monitor_names.index(self.monitor_var.get())
+
+        monitor = self.monitors[self.selected_monitor_index]
+        geometry = f"{monitor.width}x{monitor.height}+{monitor.x}+{monitor.y}"
+        self.clock_window.geometry(geometry)
+        self.label.configure(font=(self.font_family, self.font_size), bg=self.bg_color)
+        self.clock_window.configure(bg=self.bg_color)
 
     def get_time_str(self):
         now = datetime.now()


### PR DESCRIPTION
## Summary
- implement full settings window
- allow choosing monitor (fallback if enumeration fails)
- let user choose font family and size
- support background color changes
- update time format toggle

## Testing
- `python -m py_compile window_clock.py`
- `python window_clock.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_685f44449d7083318f173bb8f3daa1a4