### PR TITLE
Fix Linux monitor parsing

### DIFF
--- a/monitor_utils.py
+++ b/monitor_utils.py
@@ -112,7 +112,9 @@ def _monitors_linux():
             name = parts[-1]
             geometry = parts[2]
             size, position = geometry.split("+", 1)
-            width, height = size.split("x")
+            width_str, height_str = size.split("x")
+            width = width_str.split("/")[0]
+            height = height_str.split("/")[0]
             x, y = position.split("+")
             monitors.append(Monitor(int(width), int(height), int(x), int(y), name=name))
     return monitors


### PR DESCRIPTION
## Summary
- ensure `/` parts from xrandr output are ignored when detecting monitors

## Testing
- `python -m py_compile monitor_utils.py window_clock.py`


------
https://chatgpt.com/codex/tasks/task_e_685f4c8beda48331a2255501bd4af9a7