### PR TITLE
Fix fullscreen layout on secondary displays

### DIFF
--- a/window_clock.py
+++ b/window_clock.py
@@ -114,6 +114,12 @@ class WindowClock:
         y_sign = '+' if monitor.y >= 0 else ''
         geometry = f"{monitor.width}x{monitor.height}{x_sign}{monitor.x}{y_sign}{monitor.y}"
         self.clock_window.geometry(geometry)
+        # Force fullscreen to ensure the window covers the entire selected monitor
+        try:
+            self.clock_window.attributes("-fullscreen", True)
+        except tk.TclError:
+            # attributes('-fullscreen') may not be supported on some platforms
+            pass
         self.canvas.configure(bg=self.bg_color)
         self.canvas.itemconfigure(self.text_item, font=(self.font_family, self.font_size), fill=self.font_color)
         if self.selection_rect:


### PR DESCRIPTION
## Summary
- adjust `apply_settings` to force the clock window fullscreen after positioning

## Testing
- `python -m py_compile monitor_utils.py window_clock.py`
- `python window_clock.py --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_685f4f94e488833185077ef7ab7b933f